### PR TITLE
Add logic for minor differences in "fan" and "dataplane_processors" JSON Output in influxdb_converter.py

### DIFF
--- a/influxdb_converter.py
+++ b/influxdb_converter.py
@@ -636,21 +636,26 @@ class SystemConverter(DataConverter):
             # Some versions may have it directly
             data_processors = resource_monitor
         
-        # Get dp0 data (primary dataplane processor)
-        if 'dp0' not in data_processors:
+        # Get dataplane processor
+        if 'dp0' in data_processors:
+            dp_key = 'dp0'
+        ## Added for compatibility with PA5200 series
+        elif 's1dp0' in data_processors:
+            dp_key = 's1dp0'
+        else:
             return None
         
-        dp0 = data_processors['dp0']
+        dp_data = data_processors[dp_key]
         
         # Get second-level data
-        if 'second' not in dp0:
+        if 'second' not in dp_data:
             return None
         
-        second_data = dp0['second']
+        second_data = dp_data['second']
         
         tags = {
             'hostname': hostname,
-            'dp_id': 'dp0'
+            'dp_id': dp_key
         }
         
         fields = {}
@@ -739,17 +744,22 @@ class SystemConverter(DataConverter):
         else:
             data_processors = resource_monitor
         
-        # Get dp0 data (primary dataplane processor)
-        if 'dp0' not in data_processors:
+        # Get dataplane processor
+        if 'dp0' in data_processors:
+            dp_key = 'dp0'
+        ## Added for compatibility with PA5200 series
+        elif 's1dp0' in data_processors:
+            dp_key = 's1dp0'
+        else:
             return lines
         
-        dp0 = data_processors['dp0']
+        dp_data = data_processors[dp_key]
         
         # Get second-level data
-        if 'second' not in dp0:
+        if 'second' not in dp_data:
             return lines
         
-        second_data = dp0['second']
+        second_data = dp_data['second']
         
         # Get per-core CPU load averages
         if 'cpu-load-average' not in second_data:
@@ -771,7 +781,7 @@ class SystemConverter(DataConverter):
             if core_id is not None and value is not None:
                 tags = {
                     'hostname': hostname,
-                    'dp_id': 'dp0',
+                    'dp_id': dp_key,
                     'core_id': str(core_id)
                 }
                 
@@ -809,8 +819,15 @@ class EnvironmentalConverter(DataConverter):
             lines.extend(thermal_lines)
         
         # 2. Fan Sensors
-        if 'fan' in env_data:
-            fan_lines = self._convert_fan(hostname, env_data['fan'])
+        if 'fans' in env_data:
+            fan_key = 'fans'
+        elif 'fan' in env_data:
+            fan_key = 'fan'
+        else:
+            fan_key = None
+
+        if fan_key:
+            fan_lines = self._convert_fan(hostname, env_data[fan_key])
             lines.extend(fan_lines)
         
         # 3. Power/Voltage Sensors


### PR DESCRIPTION
**Update influxdb_converter.py** - Add logic to select either 's1dp0' or 'dp0' for compatibility

PA5200 series returns s1dp0 as dataplane processor. PA5400 series returns dp0.

Sample JSON Output PANOS 11.2.9 returns on PA5200 series:

        "extended_cpu": {
          "resource-monitor": {
            "data-processors": {
              "s1dp0": {
                "second": {
                  "task": {

**Update influxdb_converter.py** - Add logic to select 'fan' or 'fans' for compatibility

Either select 'fan' or 'fans' depending on the key returned from the environmental JSON data. 'fans' is used in PANOS 11.x.

Sample JSON Output PANOS 11.2.9 returns on PA5200 and 5400 series:

          "fans": {
            "Slot1": {
              "entry": [
                {
                  "slot": 1,
                  "description": "Fan #1.1 RPM",
                  "alarm": false,
                  "RPMs": 4620,
                  "min": 3000
                },